### PR TITLE
Adapt scoring and transcription

### DIFF
--- a/clemcore/__init__.py
+++ b/clemcore/__init__.py
@@ -100,56 +100,57 @@ def run(game: Union[str, Dict, GameSpec], model_specs: List[backends.ModelSpec],
         logger.error(e, exc_info=True)
 
 
-def score(game_name: str, experiment_name: str = None, results_dir: str = None):
+def score(game: Union[str, Dict, GameSpec], experiment_name: str = None, results_dir: str = None):
     """Calculate scores from a game benchmark run's records and store score files.
     Args:
-        game_name: Name of the game, matching the game's name in the game registry.
+        game: Name of the game, matching the game's name in the game registry, OR GameSpec-like dict, OR GameSpec.
         experiment_name: Name of the experiment to score. Corresponds to the experiment directory in each player pair
             subdirectory in the results directory.
         results_dir: Path to the results directory in which the benchmark records are stored.
     """
-    logger.info(f"Scoring game {game_name}")
-    stdout_logger.info(f"Scoring game {game_name}")
+    logger.info(f"Scoring game {game}")
+    stdout_logger.info(f"Scoring game {game}")
 
     if experiment_name:
         logger.info("Only scoring experiment: %s", experiment_name)
-    game_spec = clemgame.select_game(game_name)
-    try:
-        game = clemgame.load_game(game_spec, do_setup=False)
-        if experiment_name:
-            game.filter_experiment.append(experiment_name)
-        time_start = datetime.now()
-        game.compute_scores(results_dir)
-        time_end = datetime.now()
-        logger.info(f"Scoring {game.game_name} took {str(time_end - time_start)}")
-    except Exception as e:
-        stdout_logger.exception(e)
-        logger.error(e, exc_info=True)
+    game_specs = clemgame.select_game(game)
+    for game_spec in game_specs:
+        try:
+            game = clemgame.load_game(game_spec, do_setup=False)
+            if experiment_name:
+                game.filter_experiment.append(experiment_name)
+            time_start = datetime.now()
+            game.compute_scores(results_dir)
+            time_end = datetime.now()
+            logger.info(f"Scoring {game.game_name} took {str(time_end - time_start)}")
+        except Exception as e:
+            stdout_logger.exception(e)
+            logger.error(e, exc_info=True)
 
 
-def transcripts(game_name: str, experiment_name: str = None, results_dir: str = None):
+def transcripts(game: Union[str, Dict, GameSpec], experiment_name: str = None, results_dir: str = None):
     """Create episode transcripts from a game benchmark run's records and store transcript files.
     Args:
-        game_name: Name of the game, matching the game's name in the game registry.
+        game: Name of the game, matching the game's name in the game registry, OR GameSpec-like dict, OR GameSpec.
         experiment_name: Name of the experiment to score. Corresponds to the experiment directory in each player pair
             subdirectory in the results directory.
         results_dir: Path to the results directory in which the benchmark records are stored.
     """
-    logger.info(f"Transcribing game {game_name}")
-    stdout_logger.info(f"Transcribing game {game_name}")
+    logger.info(f"Transcribing game {game}")
+    stdout_logger.info(f"Transcribing game {game}")
     if experiment_name:
         logger.info("Only transcribing experiment: %s", experiment_name)
-    game_spec = clemgame.select_game(game_name)
-    try:
-        game = clemgame.load_game(game_spec, do_setup=False)
-        if experiment_name:
-            game.filter_experiment.append(experiment_name)
-        time_start = datetime.now()
-        game.build_transcripts(results_dir)
-        time_end = datetime.now()
-        logger.info(f"Building transcripts for {game.game_name} took {str(time_end - time_start)}")
-    except Exception as e:
-        stdout_logger.exception(e)
-        logger.error(e, exc_info=True)
-
+    game_specs = clemgame.select_game(game)
+    for game_spec in game_specs:
+        try:
+            game = clemgame.load_game(game_spec, do_setup=False)
+            if experiment_name:
+                game.filter_experiment.append(experiment_name)
+            time_start = datetime.now()
+            game.build_transcripts(results_dir)
+            time_end = datetime.now()
+            logger.info(f"Building transcripts for {game.game_name} took {str(time_end - time_start)}")
+        except Exception as e:
+            stdout_logger.exception(e)
+            logger.error(e, exc_info=True)
 

--- a/clemcore/clemgame/__init__.py
+++ b/clemcore/clemgame/__init__.py
@@ -235,6 +235,8 @@ def select_game(game: Union[str, Dict, GameSpec]) -> List[GameSpec]:
                     continue
 
         return matching_registered_games
+    elif game == "all":
+        return game_registry
     else:
         # return first entry that matches game_name
         for registered_game_spec in game_registry:

--- a/clemcore/clemgame/__init__.py
+++ b/clemcore/clemgame/__init__.py
@@ -200,7 +200,7 @@ def select_game(game: Union[str, Dict, GameSpec]) -> List[GameSpec]:
         game = json.loads(game)
         game_is_dict = True
     except Exception:
-        print(f"Passed game {game} does not parse as JSON!")
+        logger.info(f"Passed game '{game}' does not parse as JSON!")
         pass
 
     # convert passed JSON to GameSpec for unification:

--- a/clemcore/cli.py
+++ b/clemcore/cli.py
@@ -121,7 +121,7 @@ if __name__ == "__main__":
     run_parser.add_argument("-e", "--experiment_name", type=str,
                             help="Optional argument to only run a specific experiment")
     run_parser.add_argument("-g", "--game", type=str,
-                            required=True, help="A specific game name (see ls).")
+                            required=True, help="A specific game name (see ls), or a GameSpec-like JSON string object.")
     run_parser.add_argument("-t", "--temperature", type=float, default=0.0,
                             help="Argument to specify sampling temperature for the models. Default: 0.0.")
     run_parser.add_argument("-l", "--max_tokens", type=int, default=100,
@@ -139,7 +139,8 @@ if __name__ == "__main__":
     score_parser.add_argument("-e", "--experiment_name", type=str,
                               help="Optional argument to only run a specific experiment")
     score_parser.add_argument("-g", "--game", type=str,
-                              help="A specific game name (see ls).")
+                              help='A specific game name (see ls), a GameSpec-like JSON string object or "all" (default).',
+                              default="all")
     score_parser.add_argument("-r", "--results_dir", type=str, default="results",
                               help="A relative or absolute path to the results root directory. "
                                    "For example '-r results/v1.5/de‘ or '-r /absolute/path/for/results'. "
@@ -149,7 +150,8 @@ if __name__ == "__main__":
     transcribe_parser.add_argument("-e", "--experiment_name", type=str,
                                    help="Optional argument to only run a specific experiment")
     transcribe_parser.add_argument("-g", "--game", type=str,
-                                   help="A specific game name (see ls).", default="all")
+                                   help='A specific game name (see ls), a GameSpec-like JSON string object or "all" (default).',
+                                   default="all")
     transcribe_parser.add_argument("-r", "--results_dir", type=str, default="results",
                                    help="A relative or absolute path to the results root directory. "
                                         "For example '-r results/v1.5/de‘ or '-r /absolute/path/for/results'. "


### PR DESCRIPTION
The overhauled game selection now returns a list of GameSpecs, and the scoring and transcription functions need to iterate over this list to properly access game specifications.

Commit:
Adapt clemcore.score() and clemcore.transcripts() functions to iterate over list of GameSpecs returned by clemgame.select_game();
Change print to logger.info for non-JSON-parseable game info in clemgame.select_game()